### PR TITLE
Append columns used as partition keys

### DIFF
--- a/dbt/adapters/athena/impl.py
+++ b/dbt/adapters/athena/impl.py
@@ -68,7 +68,8 @@ class AthenaAdapter(SQLAdapter):
                     schema=schema_relation.schema,
                     quote_policy=quote_policy,
                     type=rel_type,
-                    column_information=table["StorageDescriptor"]["Columns"],
+                    # StorageDescriptor.Columns doesn't include columns used as partition key
+                    column_information=table["StorageDescriptor"]["Columns"] + table["PartitionKeys"],
                 )
                 relations.append(relation)
             return relations


### PR DESCRIPTION
Athena’s partition key is a part of a table column, but `StorageDescriptor.Columns` in Glue API response doesn’t include columns used as a partition key. So, return value of `AthenaAdapter.get_columns_in_relation()` of the current implementation doesn’t include columns used as a partition key too.

This pull request appends `PartitionKeys` in Glue API (metadata for partition keys, it has the same structure as `StorageDescriptor.Columns`) to `AthenaRelation.column_information` for including columns used as partition key in return value of `AthenaAdapter.get_columns_in_relation()`.